### PR TITLE
adding missing build reqs to spec file

### DIFF
--- a/libcrange.spec
+++ b/libcrange.spec
@@ -9,7 +9,7 @@ URL:        http://github.com/boinger/libcrange
 Source0:    %{name}-latest.tar.gz
 BuildRoot:  %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
-BuildRequires: apr-devel, libyaml-devel, pcre-devel, perl-devel, sqlite-devel
+BuildRequires: apr-devel, libyaml-devel, pcre-devel, perl-devel, sqlite-devel, automake, libtool, zlib-devel, flex, bison, perl-ExtUtils-Embed
 Requires: apr, flex, libyaml, pcre, perl, perl-YAML-Syck, perl-core, perl-libs, sqlite
 
 


### PR DESCRIPTION
Added a couple of missing packages to BuildRequires.

The added packages were missing from a minimal install of CentOS 7:

$ cat /etc/redhat-release
CentOS Linux release 7.0.1406 (Core)
