### PR TITLE
Switch from YYPARSE_PARAM / YYLEX_PARAM; they are removed in bison 3.x. ...

### DIFF
--- a/source/src/range.c
+++ b/source/src/range.c
@@ -20,9 +20,9 @@ Copyrights licensed under the New BSD License. See the accompanying LICENSE file
 int yyparse(void*);
 
 static range_request* current_rr;
-void yyerror(const char* s)
+void yyerror (YYLTYPE *locp, void * scanner, char const *msg)
 {
-    range_request_warn(current_rr, "%s", s);
+    range_request_warn(current_rr, "%s", msg);
 }
 
 void range_destroy(range* r)

--- a/source/src/range_parser.y
+++ b/source/src/range_parser.y
@@ -3,20 +3,20 @@
 #include "range.h"
 #include "ast.h"
 
-#define YYPARSE_PARAM scanner
-#define YYLEX_PARAM scanner
 #include "range_parser_defs.h"
 
 %}
 
 %pure-parser
+%lex-param {void * scanner}
+%parse-param {void * scanner}
 %locations
 %error-verbose
 %start main
 
 %token tGROUP tUNION tDIFF tINTER tNOT tADMIN tGET_CLUSTER
 %token tGET_GROUP tCLUSTER tCOLON tLPAREN tRPAREN tSEMI
-%token tLBRACE tRBRACE tEOL tCOLON tERROR tHASH tEOF tWHITESPACE
+%token tLBRACE tRBRACE tEOL tERROR tHASH tEOF tWHITESPACE
 
 %token <strconst> tLITERAL tREGEX tNONRANGE_LITERAL
 %token <rangeparts> tRANGEPARTS

--- a/source/src/range_parser_defs.h
+++ b/source/src/range_parser_defs.h
@@ -22,7 +22,7 @@ typedef struct YYLTYPE
 } YYLTYPE;
 #define YYLTYPE_IS_DECLARED 1
 
-void yyerror(const char* s);
+void yyerror (YYLTYPE *locp, void * scanner, char const *msg);
 int yylex(YYSTYPE* yylval_param, YYLTYPE* yylloc_param, void* yyscanner);
 
 


### PR DESCRIPTION
...Fix repeat of tCOLON which is now an error.
